### PR TITLE
Fix -Wchar-subscripts warning on illumos.

### DIFF
--- a/include/cctz/civil_time_detail.h
+++ b/include/cctz/civil_time_detail.h
@@ -95,7 +95,8 @@ CONSTEXPR_F int days_per_month(year_t y, month_t m) noexcept {
   CONSTEXPR_D int k_days_per_month[1 + 12] = {
       -1, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31  // non leap year
   };
-  return k_days_per_month[m] + (m == 2 && is_leap_year(y));
+  // Avoid -Wchar-subscripts warning (int_fast8_t may be char)
+  return k_days_per_month[static_cast<int>(m)] + (m == 2 && is_leap_year(y));
 }
 
 CONSTEXPR_F fields n_day(year_t y, month_t m, diff_t d, diff_t cd,


### PR DESCRIPTION
Building ClickHouse on illumos throws an error on cctz. This happens because `month_t` is aliased to `int_fast8_t`, which is a plain char by default on illumos:

https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/int_types.h#L74-L78

This patch static_casts `month_t` to `int` before indexing into an array to avoid the error.